### PR TITLE
Add edge_arrow_ends argument to clustree.matrix to flip arrows if wanted

### DIFF
--- a/R/clustree.R
+++ b/R/clustree.R
@@ -43,6 +43,8 @@
 #' for `SingleCellExperiment` objects it must be a name in
 #' [SummarizedExperiment::assayNames()], for a `seurat` object it must be one of
 #' `data`, `raw.data` or `scale.data`
+#' @param edge_arrow_ends One of \code{"last"}, \code{"first"}, or \code{"both"},
+#' indicating which ends of the line to draw arrow heads if \code{edge_arrow = "TRUE"}.
 #' @param ... extra parameters passed to other methods
 #'
 #' @details
@@ -115,6 +117,7 @@ clustree.matrix <- function(x, prefix,
                             node_text_colour = "black",
                             edge_width       = 1.5,
                             edge_arrow       = TRUE,
+                            edge_arrow_ends  = "last",
                             layout           = c("tree", "sugiyama"),
                             ...) {
 
@@ -165,16 +168,25 @@ clustree.matrix <- function(x, prefix,
     # Plot edges
     if (edge_arrow) {
         if (is.numeric(node_size)) {
-            circle_size <- node_size * 1.5
+            circle_size_end <- ifelse(edge_arrow_ends == "first", 0.1,
+                                      node_size * 1.5)
+            circle_size_start <- ifelse(edge_arrow_ends == "last", 0.1,
+                                        node_size * 1.5)
         } else {
-            circle_size <- mean(node_size_range) * 1.5
+            circle_size_end <- ifelse(edge_arrow_ends == "first", 0.1,
+                                  mean(node_size_range) * 1.5)
+            circle_size_start <- ifelse(edge_arrow_ends == "last", 0.1,
+                                        mean(node_size_range)*1.5)
         }
         gg <- gg + geom_edge_link(arrow = arrow(length = unit(edge_width * 5,
-                                                              "points")),
-                                  end_cap = circle(circle_size, "points"),
+                                                              "points"),
+                                                ends = edge_arrow_ends),
+                                  end_cap = circle(circle_size_end, "points"),
+                                  start_cap = circle(circle_size_start, "points"),
                                   edge_width = edge_width,
                                   aes_(colour = ~count,
                                       alpha = ~in_prop))
+
     } else {
         gg <- gg + geom_edge_link(edge_width = edge_width,
                                  aes_(colour = ~count, alpha = ~in_prop))

--- a/man/clustree.Rd
+++ b/man/clustree.Rd
@@ -15,8 +15,8 @@ clustree(x, ...)
   node_colour_aggr = NULL, node_size = "size", node_size_aggr = NULL,
   node_size_range = c(4, 15), node_alpha = 1, node_alpha_aggr = NULL,
   node_text_size = 3, scale_node_text = FALSE, node_text_colour = "black",
-  edge_width = 1.5, edge_arrow = TRUE, layout = c("tree", "sugiyama"),
-  ...)
+  edge_width = 1.5, edge_arrow = TRUE, edge_arrow_ends = "last",
+  layout = c("tree", "sugiyama"), ...)
 
 \method{clustree}{data.frame}(x, prefix, ...)
 
@@ -79,6 +79,9 @@ with the node size}
 \item{edge_width}{numeric value giving the width of plotted edges}
 
 \item{edge_arrow}{logical indicating whether to add an arrow to edges}
+
+\item{edge_arrow_ends}{One of \code{"last"}, \code{"first"}, or \code{"both"},
+indicating which ends of the line to draw arrow heads if \code{edge_arrow = "TRUE"}.}
 
 \item{layout}{character specifying the "tree" or "sugiyama" layout, see
 \code{\link[igraph:layout_as_tree]{igraph::layout_as_tree()}} and \code{\link[igraph:layout_with_sugiyama]{igraph::layout_with_sugiyama()}} for details}


### PR DESCRIPTION
Hi @lazappi,

Thanks for your awesome clustree package, it's such a great way to visualize clustering resolutions! I'm sending a pull request for a minor update: I wanted to be able to choose whether edge arrows point forwards or backwards as I am using your package to illustrate a general method to aggregate as well as split clusters; for the latter, clustree works as is perfectly, but for the former I wanted arrows to be able to point in the opposite direction.

I've just added an `edge_arrow_ends` argument to `clustree.matrix`, which by default takes the value of `"last"` (same behavior as now), but can also take values of `"first"` or `"both"`. This is then passed to the arrow call in the `geom_edge_link` function.

Thanks again for your great work!
- Andrea