### PR TITLE
Do not match on complete error message of checkmate in tests

### DIFF
--- a/tests/testthat/test-aesthetics.R
+++ b/tests/testthat/test-aesthetics.R
@@ -21,7 +21,7 @@ test_that("static node_colour works", {
     expect_is(clustree(iris_clusts, prefix = "K", node_colour = "purple"),
               c("gg", "ggplot"))
     expect_error(clustree(iris_clusts, prefix = "K", node_colour = -1),
-                 "All elements must be >= 0")
+                 ">= 0")
     expect_error(clustree(iris_clusts, prefix = "K", node_colour = "XXXX"),
                  "not a valid colour name")
 })
@@ -43,7 +43,7 @@ test_that("static node_size works", {
     expect_is(clustree(iris_clusts, prefix = "K", node_size = 1),
               c("gg", "ggplot"))
     expect_error(clustree(iris_clusts, prefix = "K", node_size = -1),
-                 "All elements must be >= 0")
+                 ">= 0")
     expect_error(clustree(iris_clusts, prefix = "K", node_size = "XXXX"),
                  "must be one of")
 })
@@ -65,9 +65,9 @@ test_that("static node_size works", {
     expect_is(clustree(iris_clusts, prefix = "K", node_alpha = 1),
               c("gg", "ggplot"))
     expect_error(clustree(iris_clusts, prefix = "K", node_alpha = -1),
-                 "All elements must be >= 0")
+                 ">= 0")
     expect_error(clustree(iris_clusts, prefix = "K", node_alpha = 2),
-                 "All elements must be <= 1")
+                 "<= 1")
     expect_error(clustree(iris_clusts, prefix = "K", node_alpha = "XXXX"),
                  "must be one of")
 })


### PR DESCRIPTION
Hi there,

While preparing a new release of checkmate, I improved some error messages to provide additional information, e.g. the location of the first missing value in a vector. This unfortunately broke a unit test in your package. This PR should fix the test in question. Instead of matching on the complete sentence, the new pattern just matches the comparison chars.
I currently see no better way around this to make this more future-proof ...

It would be great if you could release a new version to CRAN in the next few weeks.

Best,
Michel